### PR TITLE
Implemented move command for #6

### DIFF
--- a/command/command.go
+++ b/command/command.go
@@ -44,6 +44,10 @@ var Commands = map[string]Command{
 		Exec: repo,
 		Help: "Sends a link to the bot's repository.",
 	},
+	"move": Command{
+		Exec: move,
+		Help: moveUsage,
+	},
 	"note": moderatorOnly(Command{
 		Exec:  note,
 		Usage: noteUsage,
@@ -59,6 +63,16 @@ var parseMentionRegexp = regexp.MustCompile(`<@!?(\d+)>`)
 // parseMention takes a Discord mention string and returns the id
 func parseMention(mention string) string {
 	res := parseMentionRegexp.FindStringSubmatch(mention)
+	if len(res) < 2 {
+		return ""
+	}
+	return res[1]
+}
+
+var parseChannelMentionRegexp = regexp.MustCompile(`<#(\d+)>`)
+
+func parseChannelMention(mention string) string {
+	res := parseChannelMentionRegexp.FindStringSubmatch(mention)
 	if len(res) < 2 {
 		return ""
 	}

--- a/command/command.go
+++ b/command/command.go
@@ -27,24 +27,24 @@ type Command struct {
 }
 
 var Commands = map[string]Command{
-	"modping": Command{
+	"modping": {
 		Exec:  modping,
 		Usage: modpingUsage,
 		Help:  "Pings online mods. Don't abuse.",
 	},
-	"fetch": Command{
+	"fetch": {
 		Exec:  fetch,
 		Usage: fetchUsage,
 	},
-	"setfetch": Command{
+	"setfetch": {
 		Exec: setFetch,
 		Help: setFetchHelp,
 	},
-	"repo": Command{
+	"repo": {
 		Exec: repo,
 		Help: "Sends a link to the bot's repository.",
 	},
-	"move": Command{
+	"move": {
 		Exec: move,
 		Help: moveUsage,
 	},

--- a/command/move.go
+++ b/command/move.go
@@ -13,27 +13,27 @@ func move(ctx *Context, args []string) {
 		return
 	}
 
-	var target = parseChannelMention(args[1])
-
+	target := parseChannelMention(args[1])
 	if target == "" {
 		ctx.Reply("invalid channel")
 		return
 	}
 
-	var text = fmt.Sprintf("Continuation from <#%s>", ctx.Message.ChannelID)	
-	var mentions strings.Builder
+	var mentions []string
 	for _, a := range args[2:] {
 		var mention = parseMention(a)
 		if mention != "" {
-			mentions.WriteString(fmt.Sprintf(" <@!%s>", mention))
+			mentions = append(mentions, fmt.Sprintf("<@!%s>", mention))
 		}
 	}
-	var link =  fmt.Sprintf("<https://discord.com/channels/%s/%s/%s>", ctx.Message.GuildID, ctx.Message.ChannelID, ctx.Message.ID)
-	var m, err = ctx.Session.ChannelMessageSend(target, fmt.Sprintf("%s -%s (%s)", text, mentions.String(), link))
+
+	mentionsString := strings.Join(mentions, " ")
+	link := fmt.Sprintf("<https://discord.com/channels/%s/%s/%s>", ctx.Message.GuildID, ctx.Message.ChannelID, ctx.Message.ID)
+	m, err := ctx.Session.ChannelMessageSend(target, fmt.Sprintf("Continuation from <#%s> - %s (%s)", ctx.Message.ChannelID, mentionsString, link))
 	if err != nil {
-		ctx.Reply("error sending to channel (might not exist or no access)")
+		ctx.ReportError("error sending to channel (might not exist or no access)", err)
 		return
 	}
-	var redirect = fmt.Sprintf("<https://discord.com/channels/%s/%s/%s>", ctx.Message.GuildID, m.ChannelID, m.ID)
-	ctx.Session.ChannelMessageSend(ctx.Message.ChannelID, fmt.Sprintf("Continued at <#%s> -%s (%s)",  target, mentions.String(), redirect))
+	redirect := fmt.Sprintf("<https://discord.com/channels/%s/%s/%s>", ctx.Message.GuildID, m.ChannelID, m.ID)
+	ctx.Session.ChannelMessageSend(ctx.Message.ChannelID, fmt.Sprintf("Continued at <#%s> - %s (%s)", target, mentionsString, redirect))
 }

--- a/command/move.go
+++ b/command/move.go
@@ -1,0 +1,39 @@
+package command
+
+import (
+	"fmt"
+	"strings"
+)
+
+const moveUsage = "note <#channel> [<@user> ...]"
+
+func move(ctx *Context, args []string) {
+	if len(args) < 2 {
+		ctx.Reply("not enough arguments.")
+		return
+	}
+
+	var target = parseChannelMention(args[1])
+
+	if target == "" {
+		ctx.Reply("invalid channel")
+		return
+	}
+
+	var text = fmt.Sprintf("Continuation from <#%s>", ctx.Message.ChannelID)	
+	var mentions strings.Builder
+	for _, a := range args[2:] {
+		var mention = parseMention(a)
+		if mention != "" {
+			mentions.WriteString(fmt.Sprintf(" <@!%s>", mention))
+		}
+	}
+	var link =  fmt.Sprintf("<https://discord.com/channels/%s/%s/%s>", ctx.Message.GuildID, ctx.Message.ChannelID, ctx.Message.ID)
+	var m, err = ctx.Session.ChannelMessageSend(target, fmt.Sprintf("%s -%s (%s)", text, mentions.String(), link))
+	if err != nil {
+		ctx.Reply("error sending to channel (might not exist or no access)")
+		return
+	}
+	var redirect = fmt.Sprintf("<https://discord.com/channels/%s/%s/%s>", ctx.Message.GuildID, m.ChannelID, m.ID)
+	ctx.Session.ChannelMessageSend(ctx.Message.ChannelID, fmt.Sprintf("Continued at <#%s> -%s (%s)",  target, mentions.String(), redirect))
+}

--- a/command/move.go
+++ b/command/move.go
@@ -21,8 +21,7 @@ func move(ctx *Context, args []string) {
 
 	var mentions []string
 	for _, a := range args[2:] {
-		mention := parseMention(a)
-		if mention != "" {
+		if mention := parseMention(a); mention != "" {
 			mentions = append(mentions, fmt.Sprintf("<@!%s>", mention))
 		}
 	}

--- a/command/move.go
+++ b/command/move.go
@@ -21,7 +21,7 @@ func move(ctx *Context, args []string) {
 
 	var mentions []string
 	for _, a := range args[2:] {
-		var mention = parseMention(a)
+		mention := parseMention(a)
 		if mention != "" {
 			mentions = append(mentions, fmt.Sprintf("<@!%s>", mention))
 		}


### PR DESCRIPTION
Simple implementation of the move command, as described in #6 

I also added `parseChannelMention()` function in `command/command.go` for convenience.  

Note: I used `discord.com` and not `discordapp.com` for the links, because the latter will be deprecated in the future.