### PR TITLE
Implemented the remove (bulk delete from user) command

### DIFF
--- a/command/command.go
+++ b/command/command.go
@@ -48,10 +48,10 @@ var Commands = map[string]Command{
 		Exec: move,
 		Help: moveUsage,
 	},
-	"remove": {
+	"remove": moderatorOnly(Command{
 		Exec: remove,
 		Help: removeUsage,
-	},
+	}),
 	"note": moderatorOnly(Command{
 		Exec:  note,
 		Usage: noteUsage,

--- a/command/command.go
+++ b/command/command.go
@@ -66,7 +66,7 @@ var Commands = map[string]Command{
 	},
 	"remove": moderatorOnly(Command{
 		Exec: remove,
-		Help: removeUsage,
+		Usage: removeUsage,
 	}),
 	"note": moderatorOnly(Command{
 		Exec:  note,

--- a/command/command.go
+++ b/command/command.go
@@ -48,6 +48,10 @@ var Commands = map[string]Command{
 		Exec: move,
 		Help: moveUsage,
 	},
+	"remove": {
+		Exec: remove,
+		Help: removeUsage,
+	},
 	"note": moderatorOnly(Command{
 		Exec:  note,
 		Usage: noteUsage,

--- a/command/remove.go
+++ b/command/remove.go
@@ -59,9 +59,9 @@ Outer:
 			break
 		}
 	}
-	errBulk := ctx.Session.ChannelMessagesBulkDelete(ctx.Message.ChannelID, toDelete)
-	if errBulk != nil {
-		ctx.ReportError("could not proceed to deletion (likely missing permissions)", errBulk)
+	err = ctx.Session.ChannelMessagesBulkDelete(ctx.Message.ChannelID, toDelete)
+	if err != nil {
+		ctx.ReportError("could not proceed to deletion (likely missing permissions)", err)
 	} else {
 		ctx.Reply(fmt.Sprintf("Deleted %d messages", len(toDelete)))
 	}

--- a/command/remove.go
+++ b/command/remove.go
@@ -38,7 +38,7 @@ Outer:
 	for i := 1; i < 10; i++ {
 		messages, err := ctx.Session.ChannelMessages(ctx.Message.ChannelID, 100, before, "", "")
 		if err != nil {
-			ctx.ReportError("error", err)
+			ctx.ReportError(fmt.Sprintf("could not fetch the 100 messages preceding message of id %s (likely missing permissions to read channel history)", before), err)
 			continue
 		}
 		for _, message := range messages {
@@ -59,6 +59,10 @@ Outer:
 			break
 		}
 	}
-	ctx.Session.ChannelMessagesBulkDelete(ctx.Message.ChannelID, toDelete)
-	ctx.Reply(fmt.Sprintf("Deleted %d messages", len(toDelete)))
+	errBulk := ctx.Session.ChannelMessagesBulkDelete(ctx.Message.ChannelID, toDelete)
+	if errBulk != nil {
+		ctx.ReportError("could not proceed to deletion (likely missing permissions)", errBulk)
+	} else {
+		ctx.Reply(fmt.Sprintf("Deleted %d messages", len(toDelete)))
+	}
 }

--- a/command/remove.go
+++ b/command/remove.go
@@ -1,0 +1,66 @@
+package command
+
+import (
+	"fmt"
+	"strconv"
+	"time"
+
+	"github.com/bwmarrin/discordgo"
+)
+
+const removeUsage = "remove <amount> <@user>"
+
+func remove(ctx *Context, args []string) {
+	if len(args) < 3 {
+		ctx.Reply("not enough arguments.")
+		return
+	}
+
+	number, err := strconv.Atoi(args[1])
+	if err != nil {
+		ctx.ReportError("the first argument must be a number", err)
+		return
+	} else if number > 100 || number < 2 {
+		ctx.Reply("the first argument must be comprised between 2 and 100")
+		return
+	}
+
+	from := parseMention(args[2])
+	if from == "" {
+		ctx.Reply("the second argument must be a user mention")
+		return
+	}
+
+	var toDelete []string
+	before := ctx.Message.ID
+	breakFromOuter := false
+	tooOldThreshold := int64(1000*60*60*24*14 - 10)
+	for i := 1; i < 10; i++ {
+		messages, err := ctx.Session.ChannelMessages(ctx.Message.ChannelID, 100, before, "", "")
+		if err != nil {
+			ctx.ReportError("error", err)
+			continue
+		}
+		for _, message := range messages {
+			created, _ := discordgo.SnowflakeTimestamp(message.ID)
+			now := time.Now()
+			duration := now.Sub(created)
+			if duration.Milliseconds() > tooOldThreshold {
+				breakFromOuter = true
+				break
+			}
+			if message.Author.ID == from {
+				toDelete = append(toDelete, message.ID)
+			}
+			if len(toDelete) >= number {
+				break
+			}
+		}
+		before = messages[len(messages)-1].ID
+		if len(toDelete) >= number || len(messages) < 100 || breakFromOuter {
+			break
+		}
+	}
+	ctx.Session.ChannelMessagesBulkDelete(ctx.Message.ChannelID, toDelete)
+	ctx.Reply(fmt.Sprintf("Deleted %d messages", len(toDelete)))
+}


### PR DESCRIPTION
Implemented the remove command as described in #3  

`.remove <amount> <@user>` deletes the `amount` amount of messages from the user.
Because discord has a fetching messages limit of 100, and that we are targetting a particular user, I chose to iterate several number of times (up to 10 times) through the ranges [-100n-100; -100n] of previous messages until it gets through the required amount of messages from the particular user. If after 10 iterations, the bot cannot find the required amount of messages, it will just give up and delete the ones it has yet found.

The iterations also stop once it gets to a message that's older than 14 days since bulk delete do not work for such old messages.