### PR TITLE
Added profile (git, desc, and dotfiles commands)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+trup
 .idea/
 .env
 pglogs

--- a/command/command.go
+++ b/command/command.go
@@ -63,6 +63,11 @@ var Commands = map[string]Command{
 		Usage: dotfilesUsage,
 		Help: "Adds a dotfiles link to your profile, see with fetch",
 	},
+	"desc": Command{
+		Exec:  desc,
+		Usage: descUsage,
+		Help: "Sets or clears your description, see with fetch",
+	},
 }
 
 var parseMentionRegexp = regexp.MustCompile(`<@!?(\d+)>`)

--- a/command/command.go
+++ b/command/command.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"log"
 	"regexp"
+	"net/url"
 
 	"github.com/bwmarrin/discordgo"
 )
@@ -52,6 +53,11 @@ var Commands = map[string]Command{
 		Exec:  warn,
 		Usage: warnUsage,
 	}),
+	"git": Command{
+		Exec:  git,
+		Usage: gitUsage,
+		Help: "Adds a git link to your profile, see with fetch",
+	},
 }
 
 var parseMentionRegexp = regexp.MustCompile(`<@!?(\d+)>`)
@@ -123,4 +129,18 @@ func (ctx *Context) isModerator() bool {
 		}
 	}
 	return false
+}
+
+func isValidUrl(toTest string) bool {
+	_, err := url.ParseRequestURI(toTest)
+	if err != nil {
+		return false
+	}
+
+	u, err := url.Parse(toTest)
+	if err != nil || u.Scheme == "" || u.Host == "" {
+		return false
+	}
+
+	return true
 }

--- a/command/command.go
+++ b/command/command.go
@@ -58,6 +58,11 @@ var Commands = map[string]Command{
 		Usage: gitUsage,
 		Help: "Adds a git link to your profile, see with fetch",
 	},
+	"dotfiles": Command{
+		Exec:  dotfiles,
+		Usage: dotfilesUsage,
+		Help: "Adds a dotfiles link to your profile, see with fetch",
+	},
 }
 
 var parseMentionRegexp = regexp.MustCompile(`<@!?(\d+)>`)

--- a/command/desc.go
+++ b/command/desc.go
@@ -4,7 +4,7 @@ import (
 	"trup/db"
 )
 
-const descUsage = "desc <256_char_max_text | clear>"
+const descUsage = "desc <max_256_chars | clear>"
 
 func desc(ctx *Context, args []string) {
 	if len(args) < 2 {

--- a/command/desc.go
+++ b/command/desc.go
@@ -1,0 +1,46 @@
+package command
+
+import (
+	"trup/db"
+)
+
+const descUsage = "desc <256_char_max_text | clear>"
+
+func desc(ctx *Context, args []string) {
+	if len(args) < 2 {
+		ctx.Reply("provide some text for your description")
+		return
+	}
+
+	if args[1] == "clear" {
+		args[1] = ""
+	} else {
+		if len(args[1]) > 256 {
+			ctx.Reply("your description cannot be longer than 256 characters")
+			return
+		}
+	}
+
+	user := ctx.Message.Author.ID
+
+	profile, err := db.GetProfile(user)
+
+	if err != nil {
+		profile = db.NewProfile(user)
+	}
+
+	profile.Desc = args[1]
+	err = profile.Save()
+
+	if err != nil {
+		ctx.Reply("failed to save description")
+		return
+	}
+
+	if args[1] == "" {
+		ctx.Reply("cleared your description")
+		return
+	}
+
+	ctx.Reply("set your description to: " + args[1])
+}

--- a/command/dotfiles.go
+++ b/command/dotfiles.go
@@ -4,11 +4,11 @@ import (
 	"trup/db"
 )
 
-const gitUsage = "git <url>"
+const dotfilesUsage = "dotfiles <url>"
 
-func git(ctx *Context, args []string) {
+func dotfiles(ctx *Context, args []string) {
 	if len(args) < 2 {
-		ctx.Reply("provide a url to set for your git")
+		ctx.Reply("provide a url to set for your dotfiles")
 		return
 	}
 
@@ -25,13 +25,13 @@ func git(ctx *Context, args []string) {
 		profile = db.NewProfile(user)
 	}
 
-	profile.Git = args[1]
+	profile.Dots = args[1]
 	err = profile.Save()
 
 	if err != nil {
-		ctx.Reply("failed to save git url")
+		ctx.Reply("failed to save dotfiles url")
 		return
 	}
 
-	ctx.Reply("set your git url to " + args[1])
+	ctx.Reply("set your dotfiles url to " + args[1])
 }

--- a/command/fetch.go
+++ b/command/fetch.go
@@ -114,6 +114,28 @@ func fetch(ctx *Context, args []string) {
 		},
 		Fields: []*discordgo.MessageEmbedField{},
 	}
+
+	profile, err := db.GetProfile(user.ID)
+	if err == nil {
+		if profile.Desc != "" {
+			embed.Description = profile.Desc
+		}
+		if profile.Git != "" {
+			embed.Fields = append(embed.Fields, &discordgo.MessageEmbedField{
+				"Git",
+				profile.Git,
+				inline,
+			})
+		}
+		if profile.Dots != "" {
+			embed.Fields = append(embed.Fields, &discordgo.MessageEmbedField{
+				"Dotfiles",
+				profile.Dotfiles,
+				inline,
+			})
+		}
+	}
+
 	if info.Info.Kernel != "" {
 		embed.Fields = append(embed.Fields, &discordgo.MessageEmbedField{
 			"Kernel",

--- a/command/fetch.go
+++ b/command/fetch.go
@@ -130,7 +130,7 @@ func fetch(ctx *Context, args []string) {
 		if profile.Dots != "" {
 			embed.Fields = append(embed.Fields, &discordgo.MessageEmbedField{
 				"Dotfiles",
-				profile.Dotfiles,
+				profile.Dots,
 				inline,
 			})
 		}

--- a/command/git.go
+++ b/command/git.go
@@ -1,0 +1,40 @@
+package command
+
+import (
+	// "strings"
+	"trup/db"
+
+	// "github.com/bwmarrin/discordgo"
+)
+
+const gitUsage = "git <url>"
+
+func git(ctx *Context, args []string) {
+	if len(args) < 2 {
+		ctx.Reply("provide a url to set")	    
+		return
+	}
+    
+	if !isValidUrl(args[1]) {
+		ctx.Reply("provide a valid url")	    
+		return
+	}
+
+	user := ctx.Message.Author.ID
+
+	profile, err := db.GetProfile(user)
+
+	if err != nil {
+		profile = db.NewProfile(user)
+	}
+
+	profile.Git = args[1]
+	err = profile.Save()
+
+	if err != nil {
+		ctx.Reply("failed to save git url")	    
+		return
+	}
+
+	ctx.Reply("set git url to " + args[1])	    
+}

--- a/db/profile.go
+++ b/db/profile.go
@@ -6,15 +6,15 @@ import (
 
 type Profile struct {
 	User string
-	Git string
+	Git  string
 	Dots string
 	Desc string
 }
 
 func NewProfile(user string) *Profile {
 	return &Profile{
-		User:       user,
-		Git: "",
+		User: user,
+		Git:  "",
 		Dots: "",
 		Desc: "",
 	}

--- a/db/profile.go
+++ b/db/profile.go
@@ -2,10 +2,7 @@ package db
 
 import (
 	"context"
-	"log"
 	"time"
-
-	"github.com/jackc/pgx"
 )
 
 type Profile struct {

--- a/db/profile.go
+++ b/db/profile.go
@@ -2,7 +2,6 @@ package db
 
 import (
 	"context"
-	"time"
 )
 
 type Profile struct {
@@ -13,7 +12,6 @@ type Profile struct {
 }
 
 func NewProfile(user string) *Profile {
-	now := time.Now()
 	return &Profile{
 		User:       user,
 		Git: "",

--- a/db/profile.go
+++ b/db/profile.go
@@ -1,0 +1,42 @@
+package db
+
+import (
+	"context"
+	"log"
+	"time"
+
+	"github.com/jackc/pgx"
+)
+
+type Profile struct {
+	User string
+	Git string
+	Dots string
+	Desc string
+}
+
+func NewProfile(user string) *Profile {
+	now := time.Now()
+	return &Profile{
+		User:       user,
+		Git: "",
+		Dots: "",
+		Desc: "",
+	}
+}
+
+func (profile *Profile) Save() error {
+	_, err := db.Exec(context.Background(), "call profile_set($1, $2, $3, $4)", profile.User, profile.Git, profile.Dots, profile.Desc)
+	return err
+}
+
+func GetProfile(user string) (*Profile, error) {
+	row := db.QueryRow(context.Background(), "select usr, git, dots, descr from profile where usr = $1", user)
+	var profile Profile
+	err := row.Scan(&profile.User, &profile.Git, &profile.Dots, &profile.Desc)
+	if err != nil {
+		return nil, err
+	}
+
+	return &profile, nil
+}

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -27,6 +27,14 @@ create table if not exists sysinfo (
     primary key (usr)
 );
 
+create table if not exists profile (
+    usr varchar,
+    git varchar,
+    dots varchar,
+    descr varchar,
+    primary key (usr)
+);
+
 create or replace procedure sysinfo_set(_usr varchar, _info jsonb, _modify_date timestamptz, _create_date timestamptz)
 language plpgsql
 as $$

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -43,3 +43,12 @@ BEGIN
 exception when unique_violation then
 	update sysinfo set info = _info, modify_date = _modify_date where usr = _usr;
 END $$;
+
+create or replace procedure profile_set(_usr varchar, _git varchar, _dots varchar, _descr varchar)
+language plpgsql
+as $$
+BEGIN
+	insert into profile(usr, git, dots, descr) values(_usr, _git, _dots, _descr);
+exception when unique_violation then
+	update profile set usr = _usr, git = _git, dots = _dots, descr = _descr where usr = _usr;
+END $$;


### PR DESCRIPTION
Implement the `git`, `desc`, and `dotfiles` commands as described in issue #1 

I added a new table to the database schema called profile to store non-system related data, namely a link to a user's git, dotfiles, and a user's description.
This data can be set with the new `git`, `desc`, and `dotfiles` commands, and can be viewed with the `fetch` command.
The description can only be 256 characters long and can be cleared with `.desc clear`

Note that you will of course need to create the new profile table in order to run this version of the bot.