### PR TITLE
Implemented optional database

### DIFF
--- a/command/command.go
+++ b/command/command.go
@@ -5,6 +5,7 @@ import (
 	"log"
 	"net/url"
 	"regexp"
+	"trup/db"
 
 	"github.com/bwmarrin/discordgo"
 )
@@ -36,14 +37,14 @@ var Commands = map[string]Command{
 		Usage: modpingUsage,
 		Help:  modpingHelp,
 	},
-	"fetch": {
+	"fetch": needsDatabase(Command{
 		Exec:  fetch,
 		Usage: fetchUsage,
-	},
-	"setfetch": {
+	}),
+	"setfetch": needsDatabase(Command{
 		Exec: setFetch,
 		Help: setFetchHelp,
-	},
+	}),
 	"repo": {
 		Exec: repo,
 		Help: repoHelp,
@@ -52,21 +53,21 @@ var Commands = map[string]Command{
 		Exec:  move,
 		Usage: moveUsage,
 	},
-	"git": {
+	"git": needsDatabase(Command{
 		Exec:  git,
 		Usage: gitUsage,
 		Help:  gitHelp,
-	},
-	"dotfiles": {
+	}),
+	"dotfiles": needsDatabase(Command{
 		Exec:  dotfiles,
 		Usage: dotfilesUsage,
 		Help:  dotfilesHelp,
-	},
-	"desc": {
+	}),
+	"desc": needsDatabase(Command{
 		Exec:  desc,
 		Usage: descUsage,
 		Help:  descHelp,
-	},
+	}),
 	"role": {
 		Exec:  role,
 		Usage: roleUsage,
@@ -86,14 +87,14 @@ var Commands = map[string]Command{
 		Usage: purgeUsage,
 		Help:  purgeHelp,
 	}),
-	"note": moderatorOnly(Command{
+	"note": moderatorOnly(needsDatabase(Command{
 		Exec:  note,
 		Usage: noteUsage,
-	}),
-	"warn": moderatorOnly(Command{
+	})),
+	"warn": moderatorOnly(needsDatabase(Command{
 		Exec:  warn,
 		Usage: warnUsage,
-	}),
+	})),
 }
 
 var parseMentionRegexp = regexp.MustCompile(`<@!?(\d+)>`)
@@ -166,6 +167,22 @@ func moderatorOnly(cmd Command) Command {
 		Usage:         cmd.Usage,
 		Help:          cmd.Help,
 		ModeratorOnly: true,
+	}
+}
+
+func needsDatabase(cmd Command) Command {
+	return Command{
+		Exec: func(ctx *Context, args []string) {
+			if db.DatabaseUsable() {
+				cmd.Exec(ctx, args)
+				return
+			}
+
+			ctx.Reply("this command is dependant on a database but that feature is disabled.")
+		},
+		Usage:         cmd.Usage,
+		Help:          cmd.Help,
+		ModeratorOnly: cmd.ModeratorOnly,
 	}
 }
 

--- a/command/command.go
+++ b/command/command.go
@@ -173,12 +173,12 @@ func moderatorOnly(cmd Command) Command {
 func needsDatabase(cmd Command) Command {
 	return Command{
 		Exec: func(ctx *Context, args []string) {
-			if db.DatabaseUsable() {
-				cmd.Exec(ctx, args)
+			if !db.DatabaseUsable() {
+				ctx.Reply("this command is dependant on a database but that feature is disabled.")
 				return
 			}
 
-			ctx.Reply("this command is dependant on a database but that feature is disabled.")
+			cmd.Exec(ctx, args)
 		},
 		Usage:         cmd.Usage,
 		Help:          cmd.Help,

--- a/db/db.go
+++ b/db/db.go
@@ -2,31 +2,27 @@ package db
 
 import (
 	"context"
-	"fmt"
 	"github.com/jackc/pgx/v4/pgxpool"
+	"log"
 	"os"
 )
 
-var (
-	db         *pgxpool.Pool
-	databaseOk = false
-)
+var db *pgxpool.Pool
 
 func DatabaseUsable() bool {
-	return databaseOk
+	return db != nil
 }
 
 func init() {
 	databaseUrl := os.Getenv("DATABASE_URL")
 	if databaseUrl == "" {
-		fmt.Println("Database disabled")
+		log.Println("Database disabled")
 		return
 	}
 	conn, err := pgxpool.Connect(context.Background(), databaseUrl)
 	if err != nil {
-		fmt.Printf("Unable to connect to the database, the database features will be disabled:\n%s\n", err)
+		log.Printf("Unable to connect to the database, the database features will be disabled:\n%s\n", err)
 		return
 	}
-	databaseOk = true
 	db = conn
 }

--- a/db/db.go
+++ b/db/db.go
@@ -2,16 +2,31 @@ package db
 
 import (
 	"context"
+	"fmt"
 	"github.com/jackc/pgx/v4/pgxpool"
 	"os"
 )
 
-var db *pgxpool.Pool
+var (
+	db         *pgxpool.Pool
+	databaseOk = false
+)
+
+func DatabaseUsable() bool {
+	return databaseOk
+}
 
 func init() {
-	conn, err := pgxpool.Connect(context.Background(), os.Getenv("DATABASE_URL"))
-	if err != nil {
-		panic(err)
+	databaseUrl := os.Getenv("DATABASE_URL")
+	if databaseUrl == "" {
+		fmt.Println("Database disabled")
+		return
 	}
+	conn, err := pgxpool.Connect(context.Background(), databaseUrl)
+	if err != nil {
+		fmt.Printf("Unable to connect to the database, the database features will be disabled:\n%s\n", err)
+		return
+	}
+	databaseOk = true
 	db = conn
 }


### PR DESCRIPTION
This idea is suggested in #8 

Basically, I did it with a function that wraps the command handlers like `moderatorOnly` but called `needsDatabase` and it catches gracefully whether the database has been correctly initialized in `db` init, and prevents to command to be executed if it isn't the case.