### PR TITLE
#19 Add prints to modlog, reason now saved into db

### DIFF
--- a/command/command.go
+++ b/command/command.go
@@ -16,6 +16,7 @@ type Env struct {
 	ChannelShowcase string
 	ChannelBotlog   string
 	ChannelFeedback string
+	ChannelModlog   string
 }
 
 type Context struct {

--- a/command/mute.go
+++ b/command/mute.go
@@ -1,6 +1,7 @@
 package command
 
 import (
+	"fmt"
 	"strings"
 	"time"
 	"trup/db"
@@ -20,7 +21,7 @@ func mute(ctx *Context, args []string) {
 		start    = time.Now()
 		reason   = ""
 	)
-	if len(args) > 4 {
+	if len(args) > 3 {
 		reason = strings.Join(args[3:], " ")
 	}
 
@@ -52,6 +53,11 @@ func mute(ctx *Context, args []string) {
 	if err != nil {
 		ctx.ReportError("Failed to set note about the user", err)
 	}
-
 	ctx.Reply("User successfully muted.")
+
+	if reason != "" {
+		ctx.Session.ChannelMessageSend(ctx.Env.ChannelModlog, fmt.Sprintf("User <@%s> was muted for %s with reason %s ", user, duration, reason))
+	} else {
+		ctx.Session.ChannelMessageSend(ctx.Env.ChannelModlog, fmt.Sprintf("User <@%s> was muted for %s", user, duration))
+	}
 }

--- a/command/mute.go
+++ b/command/mute.go
@@ -55,9 +55,9 @@ func mute(ctx *Context, args []string) {
 	}
 	ctx.Reply("User successfully muted.")
 
+	r := ""
 	if reason != "" {
-		ctx.Session.ChannelMessageSend(ctx.Env.ChannelModlog, fmt.Sprintf("User <@%s> was muted for %s with reason %s ", user, duration, reason))
-	} else {
-		ctx.Session.ChannelMessageSend(ctx.Env.ChannelModlog, fmt.Sprintf("User <@%s> was muted for %s", user, duration))
+		r = " with reason: " + reason
 	}
+	ctx.Session.ChannelMessageSend(ctx.Env.ChannelModlog, fmt.Sprintf("User <@%s> was muted for %s%s.", user, duration, r))
 }

--- a/command/warn.go
+++ b/command/warn.go
@@ -49,5 +49,5 @@ func warn(ctx *Context, args []string) {
 	if reason != "" {
 		r = " with reason: " + reason
 	}
-    	ctx.Session.ChannelMessageSend(ctx.Env.ChannelModlog, fmt.Sprintf("<@%s> was warned by moderator <@%s> %s. They've been warned%s", user, ctx.Message.Author.ID, r, nth))
+    	ctx.Session.ChannelMessageSend(ctx.Env.ChannelModlog, fmt.Sprintf("<@%s> was warned by moderator <@%s>%s. They've been warned%s", user, ctx.Message.Author.ID, r, nth))
 }

--- a/command/warn.go
+++ b/command/warn.go
@@ -45,9 +45,9 @@ func warn(ctx *Context, args []string) {
 
 	ctx.Session.ChannelMessageSend(ctx.Message.ChannelID, fmt.Sprintf("<@%s> Has been warned%s with reason: %s.", user, nth, reason))
 
-	if reason == "" {
-		ctx.Session.ChannelMessageSend(ctx.Env.ChannelModlog, fmt.Sprintf("<@%s> was warned by moderator <@%s>. They've been warned%s", user, ctx.Message.Author.ID, nth))
-	} else {
-		ctx.Session.ChannelMessageSend(ctx.Env.ChannelModlog, fmt.Sprintf("<@%s> was warned by moderator <@%s> with reason: %s. They've been warned%s", user, ctx.Message.Author.ID, reason, nth))
+	r := ""
+	if reason != "" {
+		r = " with reason: " + reason
 	}
+    	ctx.Session.ChannelMessageSend(ctx.Env.ChannelModlog, fmt.Sprintf("<@%s> was warned by moderator <@%s> %s. They've been warned%s", user, ctx.Message.Author.ID, r, nth))
 }

--- a/command/warn.go
+++ b/command/warn.go
@@ -2,10 +2,11 @@ package command
 
 import (
 	"fmt"
-	"github.com/dustin/go-humanize"
 	"log"
 	"strings"
 	"trup/db"
+
+	"github.com/dustin/go-humanize"
 )
 
 const warnUsage = "warn <@user> <reason>"
@@ -43,4 +44,10 @@ func warn(ctx *Context, args []string) {
 	}
 
 	ctx.Session.ChannelMessageSend(ctx.Message.ChannelID, fmt.Sprintf("<@%s> Has been warned%s with reason: %s.", user, nth, reason))
+
+	if reason == "" {
+		ctx.Session.ChannelMessageSend(ctx.Env.ChannelModlog, fmt.Sprintf("<@%s> was warned by moderator <@%s>. They've been warned%s", user, ctx.Message.Author.ID, nth))
+	} else {
+		ctx.Session.ChannelMessageSend(ctx.Env.ChannelModlog, fmt.Sprintf("<@%s> was warned by moderator <@%s> with reason: %s. They've been warned%s", user, ctx.Message.Author.ID, reason, nth))
+	}
 }

--- a/db/mute.go
+++ b/db/mute.go
@@ -30,7 +30,7 @@ func NewMute(guildId, mod, user, reason string, start, end time.Time) *Mute {
 }
 
 func (mute *Mute) Save() error {
-	_, err := db.Exec(context.Background(), "INSERT INTO mute(id, guildid, moderator, usr, end_time, start_time,active) VALUES(uuid_generate_v4(), $1, $2, $3, $4, $5, $6)", mute.GuildId, mute.Moderator, mute.User, mute.EndTime, mute.StartTime, true)
+	_, err := db.Exec(context.Background(), "INSERT INTO mute(id, guildid, moderator, usr, end_time, start_time, active, reason) VALUES(uuid_generate_v4(), $1, $2, $3, $4, $5, $6, $7)", mute.GuildId, mute.Moderator, mute.User, mute.EndTime, mute.StartTime, true, mute.Reason)
 	return err
 }
 

--- a/main.go
+++ b/main.go
@@ -218,9 +218,9 @@ func cleanupMutesLoop(s *discordgo.Session) {
 				log.Printf("Failed to remove role %s\n", err)
 				continue
 			}
-
-			s.ChannelMessageSend(env.ChannelBotlog, "User <@" + m.User + "> is now unmuted.")
-			s.ChannelMessageSend(env.ChannelModlog, "User <@" + m.User + "> is now unmuted")
+			unmutedMsg := "User <@" + m.User + "> is now unmuted."
+			s.ChannelMessageSend(env.ChannelBotlog, unmutedMsg)
+			s.ChannelMessageSend(env.ChannelModlog, unmutedMsg)
 
 			err = db.SetMuteInactive(m.Id)
 			if err != nil {

--- a/main.go
+++ b/main.go
@@ -23,6 +23,7 @@ var (
 		RoleMute:        os.Getenv("ROLE_MUTE"),
 		ChannelBotlog:   os.Getenv("CHANNEL_BOTLOG"),
 		ChannelFeedback: os.Getenv("CHANNEL_FEEDBACK"),
+		ChannelModlog:   os.Getenv("CHANNEL_MODLOG"),
 	}
 	botId string
 	cache = newMessageCache(5000)
@@ -218,7 +219,8 @@ func cleanupMutesLoop(s *discordgo.Session) {
 				continue
 			}
 
-			s.ChannelMessageSend(env.ChannelBotlog, "User <@"+m.User+"> is now unmuted.")
+			s.ChannelMessageSend(env.ChannelBotlog, "User <@" + m.User + "> is now unmuted.")
+			s.ChannelMessageSend(env.ChannelModlog, "User <@" + m.User + "> is now unmuted")
 
 			err = db.SetMuteInactive(m.Id)
 			if err != nil {


### PR DESCRIPTION
As discussed:

Mute:

> User \@ girlgamerfeet69 was muted for 15s with reason CUTIE

Warn:

> \@ lidl papi was warned by moderator @ davidv7 with reason: test reason. They've been warned  for the 3rd time

Unmute:

> User  \@ girlgamerfeet69 is now unmuted

Also fixed the bug that didn't parse reason correctly with the command mute, and never saved it into the database either.
