### PR TITLE
Improve Context#userFromString()

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 trup
 .idea/
+.vscode/
 .env
 pglogs
 postgres/


### PR DESCRIPTION
`Context#userFromString()` now:
- only case-insensitively checks if the username is equal when a discriminator is provided
- uses case-insensitive prefix matching on both usernames and nicknames when no discriminator is provided
- returns an error if it matched more than one guild member