### PR TITLE
Fix help message for !mute command

### DIFF
--- a/command/mute.go
+++ b/command/mute.go
@@ -7,7 +7,7 @@ import (
 	"trup/db"
 )
 
-const muteUsage = "warn <@user> <duration> [reason]"
+const muteUsage = "mute <@user> <duration> [reason]"
 
 func mute(ctx *Context, args []string) {
 	if len(args) < 3 {


### PR DESCRIPTION
The usage for the `mute` command stated to run `warn <@user> <duration> [reason]` rather than `mute`.