### PR TITLE
Add a neutral reaction to polls, and enforce that you can only react once

### DIFF
--- a/command/poll.go
+++ b/command/poll.go
@@ -36,5 +36,6 @@ func poll(ctx *Context, args []string) {
 	}
 
 	ctx.Session.MessageReactionAdd(pollMessage.ChannelID, pollMessage.ID, "✅")
+	ctx.Session.MessageReactionAdd(pollMessage.ChannelID, pollMessage.ID, "🤷")
 	ctx.Session.MessageReactionAdd(pollMessage.ChannelID, pollMessage.ID, "❎")
 }


### PR DESCRIPTION
This PR makes trup automatically remove old reactions on polls if a user reacts a second time. By this it is enforced that a user can never vote both yes and no.
To give users the option to actively say "I don't care", there is a third option added to poll, represented by the 🤷 emoji.

Fixes #43 