### PR TITLE
!blocklist command

### DIFF
--- a/command/blocklist.go
+++ b/command/blocklist.go
@@ -7,7 +7,7 @@ import (
 )
 
 const (
-	blocklistUsage = "blocklist <add|remove|get> [regex]"
+	blocklistUsage = "blocklist <add|remove|list> [regex]"
 	blocklistHelp  = "Run commands related to the blocklist"
 )
 
@@ -17,7 +17,7 @@ func blocklist(ctx *Context, args []string) {
 		return
 	}
 	switch args[1] {
-	case "get":
+	case "list", "get":
 		blocklistGet(ctx)
 	case "add":
 		if len(args) < 3 {

--- a/command/blocklist.go
+++ b/command/blocklist.go
@@ -13,62 +13,71 @@ const (
 
 func blocklist(ctx *Context, args []string) {
 	if len(args) < 2 {
-		ctx.Reply("Not enough arguments")
+		ctx.Reply(blocklistUsage)
 		return
 	}
 	switch args[1] {
+	case "get":
+		blocklistGet(ctx)
 	case "add":
 		if len(args) < 3 {
 			ctx.Reply(blocklistUsage)
 			return
 		}
-		pattern := strings.Join(args[2:], " ")
-		if pattern[0] != '`' || pattern[len(pattern)-1] != '`' {
-			ctx.Reply("Please surround the pattern with `")
-			return
-		}
-
-		pattern = pattern[1 : len(pattern)-1]
-
-		err := db.AddToBlocklist(pattern)
-		if err != nil {
-			ctx.ReportError(fmt.Sprintf("Failed to add your pattern\n%s", err.Error()), err)
-			return
-		}
-		ctx.Reply(fmt.Sprintf("the pattern `%s` has been added to the blocklist", pattern))
-	case "get":
-		patterns, err := db.GetBlocklist()
-		if err != nil {
-			ctx.ReportError("Failed to fetch patterns", err)
-			return
-		}
-		ctx.Session.ChannelMessageSend(ctx.Message.ChannelID, fmt.Sprintf("Patterns in the blocklist:\n```\n%s\n```", strings.Join(patterns, "\n")))
-
+		blocklistAdd(ctx, strings.Join(args[2:], " "))
 	case "remove":
 		if len(args) < 3 {
-			ctx.Reply("Please give me your pattern")
+			ctx.Reply(blocklistUsage)
 			return
 		}
-		pattern := strings.Join(args[2:], " ")
-		if pattern[0] != '`' || pattern[len(pattern)-1] != '`' {
-			ctx.Reply("Please surround the pattern with backticks (`)")
-			return
-		}
-
-		pattern = pattern[1 : len(pattern)-1]
-
-		didDelete, err := db.RemoveFromBlocklist(pattern)
-		if err != nil {
-			ctx.ReportError("Failed to remove your pattern", err)
-			return
-		}
-		if !didDelete {
-			ctx.Reply(fmt.Sprintf("Couldn't find `%s` in the blocklist", pattern))
-			return
-		}
-		ctx.Session.ChannelMessageSend(ctx.Message.ChannelID, fmt.Sprintf("the pattern `%s` has been removed from the blocklist", pattern))
-
+		blocklistRemove(ctx, strings.Join(args[2:], " "))
 	default:
 		ctx.Reply(blocklistUsage)
 	}
+}
+
+func blocklistAdd(ctx *Context, pattern string) {
+	if pattern[0] != '`' || pattern[len(pattern)-1] != '`' {
+		ctx.Reply("Please surround the pattern with `")
+		return
+	}
+
+	pattern = pattern[1 : len(pattern)-1]
+
+	err := db.AddToBlocklist(pattern)
+	if err != nil {
+		ctx.ReportError(fmt.Sprintf("Failed to add your pattern\n%s", err.Error()), err)
+		return
+	}
+	ctx.Reply(fmt.Sprintf("the pattern `%s` has been added to the blocklist", pattern))
+}
+
+func blocklistRemove(ctx *Context, pattern string) {
+	if pattern[0] != '`' || pattern[len(pattern)-1] != '`' {
+		ctx.Reply("Please surround the pattern with backticks (`)")
+		return
+	}
+
+	pattern = pattern[1 : len(pattern)-1]
+
+	didDelete, err := db.RemoveFromBlocklist(pattern)
+	if err != nil {
+		ctx.ReportError("Failed to remove your pattern", err)
+		return
+	}
+	if !didDelete {
+		ctx.Reply(fmt.Sprintf("Couldn't find `%s` in the blocklist", pattern))
+		return
+	}
+	ctx.Session.ChannelMessageSend(ctx.Message.ChannelID, fmt.Sprintf("the pattern `%s` has been removed from the blocklist", pattern))
+
+}
+
+func blocklistGet(ctx *Context) {
+	patterns, err := db.GetBlocklist()
+	if err != nil {
+		ctx.ReportError("Failed to fetch patterns", err)
+		return
+	}
+	ctx.Session.ChannelMessageSend(ctx.Message.ChannelID, fmt.Sprintf("Patterns in the blocklist:\n```\n%s\n```", strings.Join(patterns, "\n")))
 }

--- a/command/blocklist.go
+++ b/command/blocklist.go
@@ -1,0 +1,74 @@
+package command
+
+import (
+	"fmt"
+	"strings"
+	"trup/db"
+)
+
+const (
+	blocklistUsage = "blocklist <add|remove|get> [regex]"
+	blocklistHelp  = "Run commands related to the blocklist"
+)
+
+func blocklist(ctx *Context, args []string) {
+	if len(args) < 2 {
+		ctx.Session.ChannelMessageSend(ctx.Message.ChannelID, fmt.Sprintf("Not enough arguments"))
+		return
+	}
+	switch args[1] {
+	case "add":
+		if len(args) < 3 {
+			ctx.Session.ChannelMessageSend(ctx.Message.ChannelID, fmt.Sprintf("Please give me your pattern"))
+			return
+		}
+		pattern := strings.Join(args[2:], " ")
+		if pattern[0] != '`' || pattern[len(pattern)-1] != '`' {
+			ctx.Session.ChannelMessageSend(ctx.Message.ChannelID, fmt.Sprintf("Please surround the pattern with `"))
+			return
+		}
+
+		pattern = pattern[1 : len(pattern)-1]
+
+		err := db.AddToBlocklist(pattern)
+		if err != nil {
+			ctx.ReportError("Failed to add your pattern", err)
+			return
+		}
+		ctx.Session.ChannelMessageSend(ctx.Message.ChannelID, fmt.Sprintf("the pattern `%s` has been added to the blocklist", pattern))
+	case "get":
+		patterns, err := db.GetBlocklist()
+		if err != nil {
+			ctx.ReportError("Failed to fetch patterns", err)
+			return
+		}
+		ctx.Session.ChannelMessageSend(ctx.Message.ChannelID, fmt.Sprintf("Patterns in the blocklist:\n```\n%s\n```", strings.Join(patterns, "\n")))
+
+	case "remove":
+		if len(args) < 3 {
+			ctx.Session.ChannelMessageSend(ctx.Message.ChannelID, fmt.Sprintf("Please give me your pattern"))
+			return
+		}
+		pattern := strings.Join(args[2:], " ")
+		if pattern[0] != '`' || pattern[len(pattern)-1] != '`' {
+			ctx.Session.ChannelMessageSend(ctx.Message.ChannelID, fmt.Sprintf("Please surround the pattern with `"))
+			return
+		}
+
+		pattern = pattern[1 : len(pattern)-1]
+
+		didDelete, err := db.RemoveFromBlocklist(pattern)
+		if err != nil {
+			ctx.ReportError("Failed to remove your pattern", err)
+			return
+		}
+		if !didDelete {
+			ctx.Session.ChannelMessageSend(ctx.Message.ChannelID, fmt.Sprintf("Couldn't find `%s` in the blocklist", pattern))
+			return
+		}
+		ctx.Session.ChannelMessageSend(ctx.Message.ChannelID, fmt.Sprintf("the pattern `%s` has been removed from the blocklist", pattern))
+
+	default:
+		ctx.Session.ChannelMessageSend(ctx.Message.ChannelID, fmt.Sprintf("Unknown subcommand"))
+	}
+}

--- a/command/blocklist.go
+++ b/command/blocklist.go
@@ -13,18 +13,18 @@ const (
 
 func blocklist(ctx *Context, args []string) {
 	if len(args) < 2 {
-		ctx.Session.ChannelMessageSend(ctx.Message.ChannelID, fmt.Sprintf("Not enough arguments"))
+		ctx.Reply("Not enough arguments")
 		return
 	}
 	switch args[1] {
 	case "add":
 		if len(args) < 3 {
-			ctx.Session.ChannelMessageSend(ctx.Message.ChannelID, fmt.Sprintf("Please give me your pattern"))
+			ctx.Reply(blocklistUsage)
 			return
 		}
 		pattern := strings.Join(args[2:], " ")
 		if pattern[0] != '`' || pattern[len(pattern)-1] != '`' {
-			ctx.Session.ChannelMessageSend(ctx.Message.ChannelID, fmt.Sprintf("Please surround the pattern with `"))
+			ctx.Reply("Please surround the pattern with `")
 			return
 		}
 
@@ -32,10 +32,10 @@ func blocklist(ctx *Context, args []string) {
 
 		err := db.AddToBlocklist(pattern)
 		if err != nil {
-			ctx.ReportError("Failed to add your pattern", err)
+			ctx.ReportError(fmt.Sprintf("Failed to add your pattern\n%s", err.Error()), err)
 			return
 		}
-		ctx.Session.ChannelMessageSend(ctx.Message.ChannelID, fmt.Sprintf("the pattern `%s` has been added to the blocklist", pattern))
+		ctx.Reply(fmt.Sprintf("the pattern `%s` has been added to the blocklist", pattern))
 	case "get":
 		patterns, err := db.GetBlocklist()
 		if err != nil {
@@ -46,12 +46,12 @@ func blocklist(ctx *Context, args []string) {
 
 	case "remove":
 		if len(args) < 3 {
-			ctx.Session.ChannelMessageSend(ctx.Message.ChannelID, fmt.Sprintf("Please give me your pattern"))
+			ctx.Reply("Please give me your pattern")
 			return
 		}
 		pattern := strings.Join(args[2:], " ")
 		if pattern[0] != '`' || pattern[len(pattern)-1] != '`' {
-			ctx.Session.ChannelMessageSend(ctx.Message.ChannelID, fmt.Sprintf("Please surround the pattern with `"))
+			ctx.Reply("Please surround the pattern with backticks (`)")
 			return
 		}
 
@@ -63,12 +63,12 @@ func blocklist(ctx *Context, args []string) {
 			return
 		}
 		if !didDelete {
-			ctx.Session.ChannelMessageSend(ctx.Message.ChannelID, fmt.Sprintf("Couldn't find `%s` in the blocklist", pattern))
+			ctx.Reply(fmt.Sprintf("Couldn't find `%s` in the blocklist", pattern))
 			return
 		}
 		ctx.Session.ChannelMessageSend(ctx.Message.ChannelID, fmt.Sprintf("the pattern `%s` has been removed from the blocklist", pattern))
 
 	default:
-		ctx.Session.ChannelMessageSend(ctx.Message.ChannelID, fmt.Sprintf("Unknown subcommand"))
+		ctx.Reply(blocklistUsage)
 	}
 }

--- a/command/command.go
+++ b/command/command.go
@@ -85,7 +85,7 @@ var Commands = map[string]Command{
 		Exec:  poll,
 		Usage: pollUsage,
 	},
-	"blocklist": modPrivateOnly(moderatorOnly(Command{
+	"blocklist": moderatorOnly(modPrivateOnly(Command{
 		Exec:  blocklist,
 		Usage: blocklistUsage,
 		Help:  blocklistHelp,

--- a/command/command.go
+++ b/command/command.go
@@ -84,6 +84,11 @@ var Commands = map[string]Command{
 		Exec:  poll,
 		Usage: pollUsage,
 	},
+	"blocklist": moderatorOnly(Command{
+		Exec:  blocklist,
+		Usage: blocklistUsage,
+		Help:  blocklistHelp,
+	}),
 	"purge": moderatorOnly(Command{
 		Exec:  purge,
 		Usage: purgeUsage,

--- a/command/command.go
+++ b/command/command.go
@@ -11,13 +11,14 @@ import (
 )
 
 type Env struct {
-	RoleMod         string
-	RoleMute        string
-	RoleColors      []string
-	ChannelShowcase string
-	ChannelBotlog   string
-	ChannelFeedback string
-	ChannelModlog   string
+	RoleMod            string
+	RoleMute           string
+	RoleColors         []string
+	ChannelShowcase    string
+	ChannelBotlog      string
+	ChannelFeedback    string
+	ChannelModlog      string
+	CategoryModPrivate string
 }
 
 type Context struct {
@@ -84,11 +85,11 @@ var Commands = map[string]Command{
 		Exec:  poll,
 		Usage: pollUsage,
 	},
-	"blocklist": moderatorOnly(Command{
+	"blocklist": modPrivateOnly(moderatorOnly(Command{
 		Exec:  blocklist,
 		Usage: blocklistUsage,
 		Help:  blocklistHelp,
-	}),
+	})),
 	"purge": moderatorOnly(Command{
 		Exec:  purge,
 		Usage: purgeUsage,
@@ -187,6 +188,26 @@ func (ctx *Context) Reply(msg string) {
 func (ctx *Context) ReportError(msg string, err error) {
 	log.Printf("Error Message ID: %s; ChannelID: %s; GuildID: %s; Author ID: %s; msg: %s; error: %s\n", ctx.Message.ID, ctx.Message.ChannelID, ctx.Message.GuildID, ctx.Message.Author.ID, msg, err)
 	ctx.Reply(msg)
+}
+
+func modPrivateOnly(cmd Command) Command {
+	return Command{
+		Exec: func(ctx *Context, args []string) {
+			channel, err := ctx.Session.Channel(ctx.Message.ChannelID)
+			if err != nil {
+				return
+			}
+			if channel.ParentID == ctx.Env.CategoryModPrivate {
+				cmd.Exec(ctx, args)
+				return
+			}
+
+			ctx.Reply("this command may only be used in moderator-internal channels.")
+		},
+		Usage:         cmd.Usage,
+		Help:          cmd.Help,
+		ModeratorOnly: true,
+	}
 }
 
 func moderatorOnly(cmd Command) Command {

--- a/db/blocklist.go
+++ b/db/blocklist.go
@@ -49,9 +49,10 @@ func RemoveFromBlocklist(pattern string) (bool, error) {
 	return hasNext, nil
 }
 
-func ContainsBlockedWords(message string) (bool, error) {
+func FindBlockedWordMatch(message string) (string, error) {
 	blockRegex, err := getBlockRegex()
-	return blockRegex.MatchString(message), err
+	submatch := blockRegex.FindString(message)
+	return submatch, err
 }
 
 var patternCache *regexp.Regexp

--- a/db/blocklist.go
+++ b/db/blocklist.go
@@ -2,7 +2,6 @@ package db
 
 import (
 	"context"
-	"errors"
 	"regexp"
 	"strings"
 )

--- a/db/blocklist.go
+++ b/db/blocklist.go
@@ -29,7 +29,7 @@ func AddToBlocklist(pattern string) error {
 		return err
 	}
 
-	_, err = db.Query(context.Background(), "INSERT INTO blocked_regexes VALUES ($1)", pattern)
+	_, err = db.Exec(context.Background(), "INSERT INTO blocked_regexes VALUES ($1)", pattern)
 	if err != nil {
 		return err
 	}
@@ -38,15 +38,12 @@ func AddToBlocklist(pattern string) error {
 }
 
 func RemoveFromBlocklist(pattern string) (bool, error) {
-	rows, err := db.Query(context.Background(), "DELETE FROM blocked_regexes WHERE pattern = $1 RETURNING *;", pattern)
+	commandTag, err := db.Exec(context.Background(), "DELETE FROM blocked_regexes WHERE pattern = $1 RETURNING *;", pattern)
 	if err != nil {
 		return false, err
 	}
-	// apparently, the database will only be updated after this is ran
-	hasNext := rows.Next()
 	updatePatternCache()
-
-	return hasNext, nil
+	return commandTag.RowsAffected() > 0, nil
 }
 
 func FindBlockedWordMatch(message string) (string, error) {

--- a/db/blocklist.go
+++ b/db/blocklist.go
@@ -2,6 +2,7 @@ package db
 
 import (
 	"context"
+	"errors"
 	"regexp"
 	"strings"
 )

--- a/db/blocklist.go
+++ b/db/blocklist.go
@@ -1,0 +1,88 @@
+package db
+
+import (
+	"context"
+	"regexp"
+	"strings"
+)
+
+func GetBlocklist() ([]string, error) {
+	rows, err := db.Query(context.Background(), "SELECT pattern from blocked_regexes")
+	if err != nil {
+		return nil, err
+	}
+	patterns := []string{}
+	for rows.Next() {
+		values, err := rows.Values()
+		if err != nil {
+			return nil, err
+		}
+		patterns = append(patterns, values[0].(string))
+	}
+	return patterns, nil
+}
+
+func AddToBlocklist(pattern string) error {
+	_, err := db.Query(context.Background(), "INSERT INTO blocked_regexes VALUES ($1)", pattern)
+	_, _ = getRegexCache()
+	regexCache.addPattern(pattern)
+	return err
+}
+
+func RemoveFromBlocklist(pattern string) (bool, error) {
+	rows, err := db.Query(context.Background(), "DELETE FROM blocked_regexes WHERE pattern = $1", pattern)
+	if err != nil {
+		return false, err
+	}
+	rows.Next()
+	values, err := rows.Values()
+	if err != nil {
+		return false, err
+	}
+	return values[0].(int) > 0, nil
+}
+
+type RegexCache struct {
+	patterns        []string
+	combinedPattern regexp.Regexp
+}
+
+var regexCache *RegexCache
+
+func (cache *RegexCache) addPattern(pattern string) error {
+	cache.patterns = append(cache.patterns, pattern)
+	regex, err := regexp.Compile(strings.Join(cache.patterns, "|"))
+	if err != nil {
+		return err
+	}
+	cache.combinedPattern = *regex
+	return nil
+}
+
+func getRegexCache() (*RegexCache, error) {
+	if regexCache == nil {
+		patterns, err := GetBlocklist()
+		if err != nil {
+			return nil, err
+		}
+		regex, err := regexp.Compile(strings.Join(patterns, "|"))
+		if err != nil {
+			return nil, err
+		}
+
+		regexCache = &RegexCache{
+			patterns:        patterns,
+			combinedPattern: *regex,
+		}
+
+	}
+	return regexCache, nil
+}
+
+func ContainsBlockedWords(message string) (bool, error) {
+	cache, err := getRegexCache()
+	if err != nil {
+		return false, err
+	}
+	return cache.combinedPattern.MatchString(message), nil
+}

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -47,6 +47,11 @@ CREATE TABLE IF NOT EXISTS profile (
     primary key (usr)
 );
 
+CREATE TABLE IF NOT EXISTS blocked_regexes (
+	pattern varchar,
+	primary key (pattern)
+);
+
 CREATE OR REPLACE PROCEDURE sysinfo_set(_usr varchar, _info jsonb, _modify_date timestamptz, _create_date timestamptz)
 language plpgsql
 AS $$

--- a/main.go
+++ b/main.go
@@ -106,6 +106,8 @@ func messageCreate(s *discordgo.Session, m *discordgo.MessageCreate) {
 		return
 	}
 
+	cache.add(m.ID, *m.Message)
+
 	isByModerator := false
 	for _, r := range m.Member.Roles {
 		if r == env.RoleMod {
@@ -129,8 +131,6 @@ func messageCreate(s *discordgo.Session, m *discordgo.MessageCreate) {
 			return
 		}
 	}
-
-	cache.add(m.ID, *m.Message)
 
 	if m.ChannelID == env.ChannelShowcase {
 		var validSubmission bool

--- a/main.go
+++ b/main.go
@@ -116,11 +116,15 @@ func messageCreate(s *discordgo.Session, m *discordgo.MessageCreate) {
 	if !isByModerator {
 		hasBlockedWords, err := db.ContainsBlockedWords(m.Message.Content)
 		if err != nil {
+			log.Printf("Failed to check if message \"%s\" contains blocked words\n%s\n", m.Content, err)
 			return
 		}
 
 		if hasBlockedWords {
-			s.ChannelMessageDelete(m.ChannelID, m.ID)
+			err := s.ChannelMessageDelete(m.ChannelID, m.ID)
+			if err != nil {
+				log.Printf("Failed to delete message by \"%s\" containing blocked words\n%s\n", m.Author.Username, err)
+			}
 			return
 		}
 	}

--- a/main.go
+++ b/main.go
@@ -115,7 +115,7 @@ func messageCreate(s *discordgo.Session, m *discordgo.MessageCreate) {
 	}
 
 	if !isByModerator {
-		if runMessageFilter(s, m) {
+		if wasDeleted := runMessageFilter(s, m); wasDeleted {
 			return
 		}
 	}
@@ -277,7 +277,7 @@ func cleanupMutesLoop(s *discordgo.Session) {
 	}
 }
 
-func runMessageFilter(s *discordgo.Session, m *discordgo.MessageCreate) bool {
+func runMessageFilter(s *discordgo.Session, m *discordgo.MessageCreate) (deleted bool) {
 	matchedString, err := db.FindBlockedWordMatch(m.Message.Content)
 	if err != nil {
 		log.Printf("Failed to check if message \"%s\" contains blocked words\n%s\n", m.Content, err)

--- a/main.go
+++ b/main.go
@@ -106,6 +106,25 @@ func messageCreate(s *discordgo.Session, m *discordgo.MessageCreate) {
 		return
 	}
 
+	isByModerator := false
+	for _, r := range m.Member.Roles {
+		if r == env.RoleMod {
+			isByModerator = true
+		}
+	}
+
+	if !isByModerator {
+		hasBlockedWords, err := db.ContainsBlockedWords(m.Message.Content)
+		if err != nil {
+			return
+		}
+
+		if hasBlockedWords {
+			s.ChannelMessageDelete(m.ChannelID, m.ID)
+			return
+		}
+	}
+
 	cache.add(m.ID, *m.Message)
 
 	if m.ChannelID == env.ChannelShowcase {

--- a/main.go
+++ b/main.go
@@ -17,13 +17,14 @@ import (
 var (
 	prefix = "!"
 	env    = command.Env{
-		RoleMod:         os.Getenv("ROLE_MOD"),
-		RoleColors:      strings.Split(os.Getenv("ROLE_COLORS"), ","),
-		ChannelShowcase: os.Getenv("CHANNEL_SHOWCASE"),
-		RoleMute:        os.Getenv("ROLE_MUTE"),
-		ChannelBotlog:   os.Getenv("CHANNEL_BOTLOG"),
-		ChannelFeedback: os.Getenv("CHANNEL_FEEDBACK"),
-		ChannelModlog:   os.Getenv("CHANNEL_MODLOG"),
+		RoleMod:            os.Getenv("ROLE_MOD"),
+		RoleColors:         strings.Split(os.Getenv("ROLE_COLORS"), ","),
+		ChannelShowcase:    os.Getenv("CHANNEL_SHOWCASE"),
+		RoleMute:           os.Getenv("ROLE_MUTE"),
+		ChannelBotlog:      os.Getenv("CHANNEL_BOTLOG"),
+		ChannelFeedback:    os.Getenv("CHANNEL_FEEDBACK"),
+		ChannelModlog:      os.Getenv("CHANNEL_MODLOG"),
+		CategoryModPrivate: os.Getenv("CATEGORY_MOD_PRIVATE"),
 	}
 	botId string
 	cache = newMessageCache(5000)

--- a/readme.md
+++ b/readme.md
@@ -5,6 +5,7 @@ TOKEN=your_token
 ROLE_MOD=707318869445967872
 ROLE_COLORS=707318869445967872,707318869445967872
 CHANNEL_SHOWCASE=635625917623828520
+CATEGORY_MOD_PRIVATE=635627141123538966,
 CHANNEL_FEEDBACK=
 CHANNEL_BOTLOG=
 ```
@@ -46,3 +47,4 @@ export DATABASE_URL=postgresql://user@localhost/trup
 - [tteeoo](https://github.com/tteeoo) for commands git, desc and dotfiles
 - [kayew](https://github.com/kayew) for a more explicit setfetch message
 - [davidv171](https://github.com/davidv171) for mute command
+- [elkowar](https://github.com/elkowar) for blocklist command


### PR DESCRIPTION
This PR adds the `!blocklist` command, allowing moderators to add, remove and list words in the blocklist.
The blocklist is a list of regexes that messages will be matched against, removing them if they match.
These removals are explicitly logged in botlog.
Blocklist commands can only be run from moderator internal channels, such as to not accidentally leak the list of regexes. For this to work there is a new environment variable added that has the ID of the `/su/`-category.