### PR TITLE
pfp with no username automatically shows own profile picture

### DIFF
--- a/command/pfp.go
+++ b/command/pfp.go
@@ -8,25 +8,25 @@ import (
 )
 
 const (
-	pfpUsage = "pfp <user>"
+	pfpUsage = "pfp [user]"
 	pfpHelp  = "displays the user's profile picture in highest resolution"
 )
 
 func pfp(ctx *Context, args []string) {
+	var user *discordgo.User
 	if len(args) < 2 {
-		ctx.Reply("Usage: " + pfpUsage)
-		return
+		user = ctx.Message.Author
+	} else {
+		member, err := ctx.userFromString(strings.Join(args[1:], " "))
+		if err != nil {
+			ctx.ReportError("Failed to find the user", err)
+			return
+		}
+		user = member.User
 	}
-
-	member, err := ctx.userFromString(strings.Join(args[1:], " "))
-	if err != nil {
-		ctx.ReportError("Failed to find the user", err)
-		return
-	}
-
-	avatar := member.User.AvatarURL("2048")
+	avatar := user.AvatarURL("2048")
 	ctx.Session.ChannelMessageSendEmbed(ctx.Message.ChannelID, &discordgo.MessageEmbed{
-		Title: fmt.Sprintf("%s#%s's profile picture", member.User.Username, member.User.Discriminator),
+		Title: fmt.Sprintf("%s#%s's profile picture", user.Username, user.Discriminator),
 		Image: &discordgo.MessageEmbedImage{
 			URL: avatar,
 		},


### PR DESCRIPTION
This PR adds support for just running `!pfp`, which will then show the users own profile picture.