### PR TITLE
Blocklist: Notify users, add !note entry, add context to botlog

### DIFF
--- a/command/mute.go
+++ b/command/mute.go
@@ -49,7 +49,7 @@ func mute(ctx *Context, args []string) {
 	if reason != "" {
 		reasonText = " with reason: " + reason
 	}
-	err = db.NewNote(ctx.Message.Author.ID, user, "User was muted for "+duration+reasonText).Save()
+	err = db.NewNote(ctx.Message.Author.ID, user, "User was muted for "+duration+reasonText, db.ManualNote).Save()
 	if err != nil {
 		ctx.ReportError("Failed to set note about the user", err)
 	}

--- a/command/note.go
+++ b/command/note.go
@@ -51,15 +51,28 @@ func note(ctx *Context, args []string) {
 		Fields:      make([]*discordgo.MessageEmbedField, 0, len(notes)),
 	}
 
+	takerCache := make(map[string]*discordgo.Member)
 	for _, n := range notes {
-		takerMember, err := ctx.Session.GuildMember(ctx.Message.GuildID, n.Taker)
-		if err != nil {
-			ctx.ReportError("Failed to fetch member "+n.Taker, err)
-			return
+		var takerMember *discordgo.Member
+		takerMember, hasCached := takerCache[n.Taker]
+		if !hasCached {
+			takerMember, err = ctx.Session.GuildMember(ctx.Message.GuildID, n.Taker)
+			if err != nil {
+				ctx.ReportError("Failed to fetch member "+n.Taker, err)
+				return
+			}
+			takerCache[n.Taker] = takerMember
+		}
+
+		var entryTitle string
+		if n.NoteType == db.BlocklistViolation {
+			entryTitle = "[AUTO] - Blocklist violation"
+		} else {
+			entryTitle = fmt.Sprintf("Moderator: %s#%s(%s)", takerMember.User.Username, takerMember.User.Discriminator, takerMember.User.ID)
 		}
 
 		embed.Fields = append(embed.Fields, &discordgo.MessageEmbedField{
-			Name:   fmt.Sprintf("Moderator: %s#%s(%s)", takerMember.User.Username, takerMember.User.Discriminator, takerMember.User.ID),
+			Name:   entryTitle,
 			Value:  n.Content + " - " + humanize.Time(n.CreateDate),
 			Inline: false,
 		})

--- a/command/note.go
+++ b/command/note.go
@@ -25,7 +25,7 @@ func note(ctx *Context, args []string) {
 
 	if len(args) > 2 {
 		content := strings.Join(args[2:], " ")
-		note := db.NewNote(ctx.Message.Author.ID, about, content)
+		note := db.NewNote(ctx.Message.Author.ID, about, content, db.ManualNote)
 
 		err := note.Save()
 		if err != nil {

--- a/command/warn.go
+++ b/command/warn.go
@@ -39,7 +39,7 @@ func warn(ctx *Context, args []string) {
 	}
 
 	taker := ctx.Message.Author
-	err = db.NewNote(taker.ID, user, "User was warned for: "+reason).Save()
+	err = db.NewNote(taker.ID, user, "User was warned for: "+reason, db.ManualNote).Save()
 	if err != nil {
 		log.Printf("Failed to save warning note. Error: %s\n", err)
 	}

--- a/db/note.go
+++ b/db/note.go
@@ -35,13 +35,13 @@ func NewNote(taker, about, content string, noteType NoteType) *Note {
 }
 
 func (note *Note) Save() error {
-	_, err := db.Exec(context.Background(), "INSERT INTO note(id, taker, about, content, create_date) VALUES(uuid_generate_v4(), $1, $2, $3, $4)", note.Taker, note.About, note.Content, note.CreateDate)
+	_, err := db.Exec(context.Background(), "INSERT INTO note(id, taker, about, content, note_type, create_date) VALUES(uuid_generate_v4(), $1, $2, $3, $4, $5)", note.Taker, note.About, note.Content, note.NoteType, note.CreateDate)
 	return err
 }
 
 func GetNotes(about string) ([]Note, error) {
 	var res []Note
-	rows, err := db.Query(context.Background(), "SELECT id, taker, about, content, create_date FROM note WHERE about=$1 ORDER BY create_date DESC LIMIT 25", &about)
+	rows, err := db.Query(context.Background(), "SELECT id, taker, about, content, note_type, create_date FROM note WHERE about=$1 ORDER BY create_date DESC LIMIT 25", &about)
 	if err != nil {
 		return nil, err
 	}
@@ -49,7 +49,7 @@ func GetNotes(about string) ([]Note, error) {
 
 	for rows.Next() {
 		var note Note
-		err = rows.Scan(&note.Id, &note.Taker, &note.About, &note.Content, &note.CreateDate)
+		err = rows.Scan(&note.Id, &note.Taker, &note.About, &note.Content, &note.NoteType, &note.CreateDate)
 		if err != nil {
 			return nil, err
 		}

--- a/db/note.go
+++ b/db/note.go
@@ -7,20 +7,29 @@ import (
 	"github.com/jackc/pgx/pgtype"
 )
 
+type NoteType int
+
+const (
+	ManualNote         NoteType = 0
+	BlocklistViolation NoteType = 1
+)
+
 type Note struct {
 	Id         pgtype.UUID
 	Taker      string
 	About      string
 	Content    string
+	NoteType   NoteType
 	CreateDate time.Time
 }
 
-func NewNote(taker, about, content string) *Note {
+func NewNote(taker, about, content string, noteType NoteType) *Note {
 	return &Note{
 		pgtype.UUID{},
 		taker,
 		about,
 		content,
+		noteType,
 		time.Now(),
 	}
 }

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -6,7 +6,7 @@ CREATE TABLE IF NOT EXISTS note (
     taker varchar not null,
     about varchar not null,
     content text not null,
-	note_type int not null,
+    note_type int not null,
     create_date timestamptz,
     primary key (id)
 );
@@ -58,16 +58,16 @@ CREATE OR REPLACE PROCEDURE sysinfo_set(_usr varchar, _info jsonb, _modify_date 
 language plpgsql
 AS $$
 BEGIN
-	INSERT INTO sysinfo(usr, info, modify_date, create_date) VALUES(_usr, _info, _modify_date, _create_date);
+    INSERT INTO sysinfo(usr, info, modify_date, create_date) VALUES(_usr, _info, _modify_date, _create_date);
 EXCEPTION WHEN unique_violation THEN
-	UPDATE sysinfo SET info = _info, modify_date = _modify_date WHERE usr = _usr;
+    UPDATE sysinfo SET info = _info, modify_date = _modify_date WHERE usr = _usr;
 end $$;
 
 CREATE OR REPLACE PROCEDURE profile_set(_usr varchar, _git varchar, _dotfiles varchar, _description varchar)
 language plpgsql
 AS $$
 BEGIN
-	INSERT INTO profile(usr, git, dotfiles, description) VALUES(_usr, _git, _dotfiles, _description);
+    INSERT INTO profile(usr, git, dotfiles, description) VALUES(_usr, _git, _dotfiles, _description);
 EXCEPTION WHEN unique_violation THEN
-	UPDATE profile SET git = _git, dotfiles = _dotfiles, description = _description WHERE usr = _usr;
+    UPDATE profile SET git = _git, dotfiles = _dotfiles, description = _description WHERE usr = _usr;
 END $$;

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -6,6 +6,7 @@ CREATE TABLE IF NOT EXISTS note (
     taker varchar not null,
     about varchar not null,
     content text not null,
+	note_type int not null,
     create_date timestamptz,
     primary key (id)
 );

--- a/main.go
+++ b/main.go
@@ -314,27 +314,48 @@ func logMessageAutodelete(s *discordgo.Session, m *discordgo.MessageCreate, matc
 		}
 	}
 
+	beforeMessages, err := s.ChannelMessages(m.ChannelID, 1, m.ID, "", "")
+	if err != nil {
+		log.Printf("Error fetching previous message for context of message deletion: %s\n", err)
+	}
+
+	var contextLink string
+	if len(beforeMessages) > 0 {
+		contextLink = fmt.Sprintf("[(context)](%s)", makeMessageLink(m.GuildID, beforeMessages[0]))
+	}
+
 	botlogEntry, err := s.ChannelMessageSendEmbed(env.ChannelBotlog, &discordgo.MessageEmbed{
 		Author: &discordgo.MessageEmbedAuthor{
 			Name:    "Message Autodelete",
 			IconURL: m.Message.Author.AvatarURL("128"),
 		},
 		Title:       fmt.Sprintf("%s#%s(%s) - deleted because of `%s`", m.Message.Author.Username, m.Message.Author.Discriminator, m.Message.Author.ID, matchedString),
-		Description: m.Message.Content,
+		Description: fmt.Sprintf("%s %s", m.Message.Content, contextLink),
 		Timestamp:   messageCreationDate.UTC().Format(dateFormat),
 		Footer:      footer,
 	})
 	if err != nil {
-		log.Println(err)
-		return
+		log.Printf("Error writing botlog entry for message deletion: %s\n", err)
 	}
 
-	botlogEntryLink := fmt.Sprintf("https://discord.com/channels/%s/%s/%s", m.Message.GuildID, botlogEntry.ChannelID, botlogEntry.ID)
+	deletionNoticeMsg, err := s.ChannelMessageSend(m.ChannelID, fmt.Sprintf("<@%s>, your message has been deleted and logged for containing a banned word or phrase.", m.Author.ID))
+	if err != nil {
+		log.Printf("Failed to send message deletion notice: %s\n", err)
+	}
+
+	time.AfterFunc(6*time.Second, func() {
+		s.ChannelMessageDelete(deletionNoticeMsg.ChannelID, deletionNoticeMsg.ID)
+	})
+
+	botlogEntryLink := makeMessageLink(m.Message.GuildID, botlogEntry)
 	note := db.NewNote(s.State.User.ID, m.Author.ID, fmt.Sprintf("(AUTO) Message deleted because of word `%s` [(source)](%s)", matchedString, botlogEntryLink), db.BlocklistViolation)
 	err = note.Save()
 	if err != nil {
 		log.Println(err)
 		return
 	}
+}
 
+func makeMessageLink(guildID string, m *discordgo.Message) string {
+	return fmt.Sprintf("https://discord.com/channels/%s/%s/%s", guildID, m.ChannelID, m.ID)
 }

--- a/main.go
+++ b/main.go
@@ -314,14 +314,14 @@ func logMessageAutodelete(s *discordgo.Session, m *discordgo.MessageCreate, matc
 		}
 	}
 
+	contextLink := ""
 	beforeMessages, err := s.ChannelMessages(m.ChannelID, 1, m.ID, "", "")
 	if err != nil {
 		log.Printf("Error fetching previous message for context of message deletion: %s\n", err)
-	}
-
-	var contextLink string
-	if len(beforeMessages) > 0 {
-		contextLink = fmt.Sprintf("[(context)](%s)", makeMessageLink(m.GuildID, beforeMessages[0]))
+	} else {
+		if len(beforeMessages) > 0 {
+			contextLink = fmt.Sprintf("[(context)](%s)", makeMessageLink(m.GuildID, beforeMessages[0]))
+		}
 	}
 
 	botlogEntry, err := s.ChannelMessageSendEmbed(env.ChannelBotlog, &discordgo.MessageEmbed{
@@ -348,7 +348,7 @@ func logMessageAutodelete(s *discordgo.Session, m *discordgo.MessageCreate, matc
 	})
 
 	botlogEntryLink := makeMessageLink(m.Message.GuildID, botlogEntry)
-	note := db.NewNote(s.State.User.ID, m.Author.ID, fmt.Sprintf("(AUTO) Message deleted because of word `%s` [(source)](%s)", matchedString, botlogEntryLink), db.BlocklistViolation)
+	note := db.NewNote(s.State.User.ID, m.Author.ID, fmt.Sprintf("Message deleted because of word `%s` [(source)](%s)", matchedString, botlogEntryLink), db.BlocklistViolation)
 	err = note.Save()
 	if err != nil {
 		log.Println(err)


### PR DESCRIPTION
This PR improves the ergonomics of the blocklist in several ways:
- Users are now notified of their message being deleted because of the blocklist
- If a user's message is deleted, a note get's added for that
- botlog entries for autodeletion will now contain a link to the last message that was sent before the deleted message, linking to the context of that message. 

To implement this, the Note struct and DB table has a new field, note_type, specifying if the note was created manually or as a result of autodeletion