### PR TITLE
Add a Dockerfile and docker-compose

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
-FROM golang
+FROM golang:1.14-alpine
 RUN mkdir /app
 ADD . /app
 WORKDIR /app
-RUN go mod download
-RUN go build -o main .
+RUN go mod download && \
+    go build -o main .
 CMD ["/app/main"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,7 @@
+FROM golang
+RUN mkdir /app
+ADD . /app
+WORKDIR /app
+RUN go mod download
+RUN go build -o main .
+CMD ["/app/main"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,21 @@
+version: '3'
+services:
+  trup:
+    image: trup
+    container_name: trup
+    depends_on: 
+      - postgres
+    env_file:
+      - .env
+    environment:
+      DATABASE_URL: "postgresql:///postgres/?host=postgres&database=trup"
+  postgres:
+    image: "postgres"
+    container_name: trup_postgres
+    volumes:
+      - ./postgres_data:/var/lib/postgresql/data/
+    environment:
+      POSTGRES_USER: root
+      POSTGRES_PASSWORD:
+      POSTGRES_DB: trup
+      POSTGRES_HOST_AUTH_METHOD: trust

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,21 +1,30 @@
-version: '3'
+version: '2.1'
 services:
   trup:
     image: trup
+    build: ./
     container_name: trup
-    depends_on: 
-      - postgres
     env_file:
       - .env
     environment:
-      DATABASE_URL: "postgresql:///postgres/?host=postgres&database=trup"
-  postgres:
-    image: "postgres"
+      DATABASE_URL: "postgresql://trup_postgres/trup"
+    depends_on: 
+      trup_postgres:
+        condition: service_healthy
+
+  trup_postgres:
+    image: "postgres:11"
     container_name: trup_postgres
-    volumes:
-      - ./postgres_data:/var/lib/postgresql/data/
     environment:
       POSTGRES_USER: root
       POSTGRES_PASSWORD:
       POSTGRES_DB: trup
       POSTGRES_HOST_AUTH_METHOD: trust
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready --username=root --dbname=trup"]
+      interval: 1s
+      timeout: 5s
+      retries: 10
+    volumes:
+      - ./db/structure.sql:/docker-entrypoint-initdb.d/structure.sql
+      #- ./postgres_data:/var/lib/postgresql/data/

--- a/readme.md
+++ b/readme.md
@@ -3,11 +3,23 @@
 ```sh
 TOKEN=your_token
 ROLE_MOD=707318869445967872
+ROLE_MUTE=
 ROLE_COLORS=707318869445967872,707318869445967872
 CHANNEL_SHOWCASE=635625917623828520
-CATEGORY_MOD_PRIVATE=635627141123538966,
+CATEGORY_MOD_PRIVATE=635627141123538966
 CHANNEL_FEEDBACK=
 CHANNEL_BOTLOG=
+CHANNEL_MODLOG=
+```
+
+# Setup with Docker
+
+After cloning the repository, create a file called `.env` 
+containing the necessary environment variables (as shown above) in the project root.
+
+Afterwards you can initialize the docker services by running
+```sh
+docker-compose up -d
 ```
 
 # Automatic setup with Nix


### PR DESCRIPTION
This PR adds the necessary Dockerfile and docker-compose.yml to be able to set up a Trup instance using Docker.