### PR TITLE
made the help command cleaner

### DIFF
--- a/command/help.go
+++ b/command/help.go
@@ -1,25 +1,52 @@
 package command
 
-import "strings"
+import (
+	"github.com/bwmarrin/discordgo"
+)
 
 func Help(ctx *Context, args []string) {
-	var text strings.Builder
 
+	const inline = true
+	embed := discordgo.MessageEmbed{
+		Title:  "Help",
+		Fields: []*discordgo.MessageEmbedField{},
+		Color:  ctx.Session.State.UserColor(ctx.Message.Author.ID, ctx.Message.ChannelID),
+	}
 	isCallerModerator := ctx.isModerator()
 	for name, cmd := range Commands {
 		if cmd.ModeratorOnly && !isCallerModerator {
 			continue
 		}
 
-		text.WriteString("**" + name + "**")
 		if cmd.Usage != "" {
-			text.WriteString(" - Usage: " + cmd.Usage)
+			if cmd.Help != "" {
+				embed.Fields = append(embed.Fields, &discordgo.MessageEmbedField{
+					name + " - Usage " + cmd.Usage,
+					cmd.Help,
+					inline,
+				})
+			} else {
+				embed.Fields = append(embed.Fields, &discordgo.MessageEmbedField{
+					name + " - Usage " + cmd.Usage,
+					"\u200b",
+					inline,
+				})
+			}
+		} else {
+			if cmd.Help != "" {
+				embed.Fields = append(embed.Fields, &discordgo.MessageEmbedField{
+					name,
+					cmd.Help,
+					inline,
+				})
+			} else {
+				embed.Fields = append(embed.Fields, &discordgo.MessageEmbedField{
+					name,
+					"\u200b",
+					inline,
+				})
+			}
 		}
-		if cmd.Help != "" {
-			text.WriteString("\n> " + cmd.Help)
-		}
-		text.WriteByte('\n')
 	}
-
-	ctx.Session.ChannelMessageSend(ctx.Message.ChannelID, "\n"+text.String())
+	ctx.Session.ChannelMessageSendEmbed(ctx.Message.ChannelID, &embed)
 }


### PR DESCRIPTION
I know I pulled a yandere-dev on this one with the if-else but `discordgo.MessageEmbedField.Value:` can't be empty so I had to do it

- [Preview(Compact)](https://i.fiery.me/4Rfeb.png)
- [Preview(Long)](https://i.fiery.me/WpAdL.png)