### PR TITLE
Capitalize The Second "P" in "Display protocol"

### DIFF
--- a/fetcher.sh
+++ b/fetcher.sh
@@ -14,7 +14,7 @@ Distro: ${NAME:-$DISTRIB_ID} $ver
 Kernel: $(uname -sr)
 Terminal:$term
 DE/WM: $wm
-Display protocol: $displayprot
+Display Protocol: $displayprot
 Editor: $EDITOR
 GTK3 Theme: $theme
 GTK Icon Theme: $icons


### PR DESCRIPTION
This just looks a bit off to me considering how every other word is capitalized.