### PR TITLE
Add missing space after "Terminal:$TERM"

### DIFF
--- a/fetcher.sh
+++ b/fetcher.sh
@@ -12,7 +12,7 @@ including the image, but not !git or !dotfiles
 !setfetch
 Distro: ${NAME:-$DISTRIB_ID} $ver
 Kernel: $(uname -sr)
-Terminal:$term
+Terminal: $term
 DE/WM: $wm
 Display protocol: $displayprot
 Editor: $EDITOR


### PR DESCRIPTION
Missing space looks out of place here.