### PR TITLE
Prompt for user selection in case of ambiguous user mentions

### DIFF
--- a/command/fetch.go
+++ b/command/fetch.go
@@ -104,19 +104,7 @@ func setFetch(ctx *Context, args []string) {
 
 const fetchUsage = "fetch [user]"
 
-func fetch(ctx *Context, args []string) {
-	var user *discordgo.User
-	if len(args) < 2 {
-		user = ctx.Message.Author
-	} else {
-		usr, err := ctx.userFromString(strings.Join(args[1:], " "))
-		if err != nil {
-			ctx.Reply("failed to find the user. Error: " + err.Error())
-			return
-		}
-		user = usr.User
-	}
-
+func doFetch(ctx *Context, user *discordgo.User) {
 	const inline = true
 	embed := discordgo.MessageEmbed{
 		Title:  "Fetch " + user.Username + "#" + user.Discriminator,
@@ -294,6 +282,21 @@ sysinfoEnd:
 	}
 }
 
+func fetch(ctx *Context, args []string) {
+	if len(args) < 2 {
+		doFetch(ctx, ctx.Message.Author)
+	} else {
+		err := ctx.requestUserByName(strings.Join(args[1:], " "), func(member *discordgo.Member) error {
+			doFetch(ctx, member.User)
+			return nil
+		})
+		if err != nil {
+			ctx.Reply("failed to find the user. Error: " + err.Error())
+			return
+		}
+	}
+}
+
 func getDistroImage(name string) string {
 	name = strings.ToLower(name)
 	for _, d := range distroImages {
@@ -315,7 +318,7 @@ var distroImages = []struct {
 	{name: "artix", image: "https://artixlinux.org/img/artix-logo.png"},
 	{name: "alpine", image: "https://upload.wikimedia.org/wikipedia/commons/thumb/e/e6/Alpine_Linux.svg/250px-Alpine_Linux.svg.png"},
 	{name: "alt", image: "https://upload.wikimedia.org/wikipedia/commons/thumb/4/44/AltLinux500Desktop.png/250px-AltLinux500Desktop.png"},
-	{name: "antergos", image: "https://upload.wikimedia.org/wikipedia/en/thumb/9/93/Antergos_logo_github.png/150px-Antergos_logo_github.png"},	
+	{name: "antergos", image: "https://upload.wikimedia.org/wikipedia/en/thumb/9/93/Antergos_logo_github.png/150px-Antergos_logo_github.png"},
 	{name: "backbox", image: "https://upload.wikimedia.org/wikipedia/commons/thumb/b/b2/BackBox_4.4_Screenshot.png/250px-BackBox_4.4_Screenshot.png"},
 	{name: "boss", image: "https://upload.wikimedia.org/wikipedia/en/f/f2/Bharat_Operating_System_Solutions_logo%2C_Sept_2015.png"},
 	{name: "bodhi", image: "https://upload.wikimedia.org/wikipedia/commons/thumb/f/fc/Bodhi_Linux_Logo.png/250px-Bodhi_Linux_Logo.png"},

--- a/command/pfp.go
+++ b/command/pfp.go
@@ -13,22 +13,24 @@ const (
 )
 
 func pfp(ctx *Context, args []string) {
-	var user *discordgo.User
+	callback := func(user *discordgo.User) error {
+		avatar := user.AvatarURL("2048")
+		ctx.Session.ChannelMessageSendEmbed(ctx.Message.ChannelID, &discordgo.MessageEmbed{
+			Title: fmt.Sprintf("%s#%s's profile picture", user.Username, user.Discriminator),
+			Image: &discordgo.MessageEmbedImage{
+				URL: avatar,
+			},
+		})
+		return nil
+	}
+
 	if len(args) < 2 {
-		user = ctx.Message.Author
+		callback(ctx.Message.Author)
 	} else {
-		member, err := ctx.userFromString(strings.Join(args[1:], " "))
+		err := ctx.requestUserByName(strings.Join(args[1:], " "), func(m *discordgo.Member) error { return callback(m.User) })
 		if err != nil {
 			ctx.ReportError("Failed to find the user", err)
 			return
 		}
-		user = member.User
 	}
-	avatar := user.AvatarURL("2048")
-	ctx.Session.ChannelMessageSendEmbed(ctx.Message.ChannelID, &discordgo.MessageEmbed{
-		Title: fmt.Sprintf("%s#%s's profile picture", user.Username, user.Discriminator),
-		Image: &discordgo.MessageEmbedImage{
-			URL: avatar,
-		},
-	})
 }

--- a/command/poll.go
+++ b/command/poll.go
@@ -21,7 +21,6 @@ poll multi These are my options
 	questionMaxLength = 2047
 )
 
-var numbers = []string{"1️⃣", "2️⃣", "3️⃣", "4️⃣", "5️⃣", "6️⃣", "7️⃣", "8️⃣", "9️⃣", "🔟"}
 var pollOptionLineStartPattern = regexp.MustCompile(`^\s*-|^\s*\d\.|^\s*\*`)
 
 func poll(ctx *Context, args []string) {

--- a/main.go
+++ b/main.go
@@ -74,6 +74,12 @@ func messageReactionAdd(s *discordgo.Session, m *discordgo.MessageReactionAdd) {
 	if m.UserID == botID {
 		return
 	}
+
+	didHandle, err := command.HandleMessageReaction(m.MessageReaction)
+	if didHandle || err != nil {
+		return
+	}
+
 	message, err := s.ChannelMessage(m.ChannelID, m.MessageID)
 	if err != nil {
 		return


### PR DESCRIPTION
This PR makes Trup prompt for selection of a specific user if someone runs `!pfp` or `!fetch` with an ambiguous name.

This could in the future be expanded to also work for moderation-related commands like `!warn`, `!note` or `!mute`, in which case a confirmation option should be added.
