### PR TITLE
don't delete any messages on ban

### DIFF
--- a/command/ban.go
+++ b/command/ban.go
@@ -56,7 +56,7 @@ func ban(ctx *Context, args []string) {
 		ctx.Message.GuildID,
 		user,
 		reason,
-		1,
+		0,
 	)
 	if err != nil {
 		ctx.ReportError(fmt.Sprintf("Failed to ban %s.", user), err)


### PR DESCRIPTION
it makes it harder to see the reason first-hand and in-context due to
being deleted forever unless someone has client-side logging (the bot
doesn't work with ban deletions) or screenshots