### PR TITLE
add support for detecting bedrock linux to fetcher

### DIFF
--- a/fetcher.sh
+++ b/fetcher.sh
@@ -29,7 +29,9 @@ EOF
 
 if [ "$kernel" = "Linux" ]; then
   # get distro
-  if [ -f /etc/os-release ]; then
+  if [ -f /bedrock/etc/os-release ]; then
+    . /bedrock/etc/os-release
+  elif [ -f /etc/os-release ]; then
     . /etc/os-release
   elif [ -f /etc/lsb-release ]; then
     . /etc/lsb-release


### PR DESCRIPTION
currently when running this on bedrock setup it detects stratum (distro integrated in bedrock linux) in which it currently runs
i changed it, so it will use /bedrock/etc/os-release instead of /etc/os-realease in case if its ran in bedrock linux
this change shouldnt affect other linux as they propably dont have /bedrock/etc/os-release file

github is acting weirdly hmm